### PR TITLE
Adds SoapUrl as a config setting in ZuoraConfig, and a member of ZuoraSe...

### DIFF
--- a/ZuoraMagic/Configuration/ZuoraConfig.cs
+++ b/ZuoraMagic/Configuration/ZuoraConfig.cs
@@ -1,13 +1,38 @@
-﻿namespace ZuoraMagic.Configuration
+﻿using System;
+using System.ComponentModel;
+
+namespace ZuoraMagic.Configuration
 {
     public class ZuoraConfig
     {
+        private string soapUrl;
+
         public ZuoraSession Session { get; set; }
         public bool IsSandbox { get; set; }
         public string Username { get; set; }
         public string Password { get; set; }
         public string InstanceUrl { get; set; }
-        public string SoapUrl { get; set; }
+
+        public string SoapUrl
+        {
+            get
+            {
+                // Default value present to prevent deprecating developers using the 2.9.9 and earlier implementation
+
+                if (string.IsNullOrWhiteSpace(this.soapUrl))
+                {
+                    return "/apps/services/a/54.0";
+                }
+
+                return this.soapUrl;
+            }
+
+            set
+            {
+                this.soapUrl = value;
+            }
+        }
+
         public string EnvironmentName { get; set; }
         public bool LogoutOnDisposal { get; set; }
         public bool UseSessionStore { get; set; }

--- a/ZuoraMagic/Configuration/ZuoraConfig.cs
+++ b/ZuoraMagic/Configuration/ZuoraConfig.cs
@@ -17,7 +17,7 @@ namespace ZuoraMagic.Configuration
         {
             get
             {
-                // Default value present to prevent deprecating developers using the 2.9.9 and earlier implementation
+                // Default value present to prevent deprecating developers using the 2.9.9 and earlier implementations
 
                 if (string.IsNullOrWhiteSpace(this.soapUrl))
                 {

--- a/ZuoraMagic/Configuration/ZuoraConfig.cs
+++ b/ZuoraMagic/Configuration/ZuoraConfig.cs
@@ -7,6 +7,7 @@
         public string Username { get; set; }
         public string Password { get; set; }
         public string InstanceUrl { get; set; }
+        public string SoapUrl { get; set; }
         public string EnvironmentName { get; set; }
         public bool LogoutOnDisposal { get; set; }
         public bool UseSessionStore { get; set; }

--- a/ZuoraMagic/Configuration/ZuoraSession.cs
+++ b/ZuoraMagic/Configuration/ZuoraSession.cs
@@ -6,6 +6,7 @@ namespace ZuoraMagic.Configuration
     {
         public string SessionId { get; set; }
         public string InstanceUrl { get; set; }
+        public string SoapUrl { get; set; }
         public string Environment { get; set; }
         public bool IsSandbox { get; set; }
         public DateTime LastLogin { get; set; }

--- a/ZuoraMagic/ExportApi/ExportRequestManager.cs
+++ b/ZuoraMagic/ExportApi/ExportRequestManager.cs
@@ -16,7 +16,7 @@ namespace ZuoraMagic.ExportApi
         {
             HttpRequest request = new HttpRequest
             {
-                Url = session.InstanceUrl + SoapUrl,
+                Url = session.InstanceUrl + session.SoapUrl,
                 Body = ExportCommands.CreateExport(new Export
                 {
                     Format = "csv",

--- a/ZuoraMagic/SoapApi/SoapRequestManager.cs
+++ b/ZuoraMagic/SoapApi/SoapRequestManager.cs
@@ -11,14 +11,11 @@ namespace ZuoraMagic.SoapApi
 {
     internal class SoapRequestManager
     {
-        internal static string SoapUrl = "/apps/services/a/54.0";
-
-        // TODO: Add configuration of endpoint
         internal static HttpRequest GetLoginRequest(ZuoraConfig config)
         {
             HttpRequest request = new HttpRequest
             {
-                Url = config.InstanceUrl + SoapUrl,
+                Url = config.InstanceUrl + config.SoapUrl,
                 Body = SoapCommands.Login(config.Username, config.Password),
                 Method = RequestType.POST,
             };
@@ -37,7 +34,7 @@ namespace ZuoraMagic.SoapApi
         {
             HttpRequest request = new HttpRequest
             {
-                Url = session.InstanceUrl + SoapUrl,
+                Url = session.InstanceUrl + session.SoapUrl,
                 Body = SoapCommands.Query(query, limit, session.SessionId),
                 Method = RequestType.POST,
             };
@@ -51,7 +48,7 @@ namespace ZuoraMagic.SoapApi
             string body = SoapCommands.CrudOperation(operation, session.SessionId);
             HttpRequest request = new HttpRequest
             {
-                Url = session.InstanceUrl + SoapUrl,
+                Url = session.InstanceUrl + session.SoapUrl,
                 Body = body,
                 Method = RequestType.POST,
             };
@@ -64,7 +61,7 @@ namespace ZuoraMagic.SoapApi
         {
             HttpRequest request = new HttpRequest
             {
-                Url = session.InstanceUrl + SoapUrl,
+                Url = session.InstanceUrl + session.SoapUrl,
                 Body = SoapCommands.QueryMore(queryLocator, limit, session.SessionId),
                 Method = RequestType.POST,
             };

--- a/ZuoraMagic/ZuoraClient.cs
+++ b/ZuoraMagic/ZuoraClient.cs
@@ -104,6 +104,7 @@ namespace ZuoraMagic
                     Uri instanceUrl = new Uri(result.ServerUrl);
                     session = new ZuoraSession
                     {
+                        SoapUrl = _config.SoapUrl,
                         InstanceUrl = instanceUrl.Scheme + "://" + instanceUrl.Host,
                         SessionId = result.SessionId
                     };


### PR DESCRIPTION
...ssion.  A statically typed SoapUrl was disabling users of the project from hitting the right endpoint, as the hard-coded SoapUrl was overriding the endpoint in the SoapRequestManager.  As a result of this, querying fields in Zuora found in later versions of their WSDL would return errors, the hard-coded version was 54.0 and as of today we are at 64.0
